### PR TITLE
Fix dateExpires to be clear it works for all types

### DIFF
--- a/content/saasquatch-api.yaml
+++ b/content/saasquatch-api.yaml
@@ -2618,7 +2618,7 @@ definitions:
           - FUELTANK
       dateExpires:
         type: integer
-        description: "Timestamp of when this reward is set to expire. Works with: `PCT_DISCOUNT`"
+        description: "Timestamp of when this reward is set to expire."
         example: 1471028988000
       dateScheduledFor:
         type: integer


### PR DESCRIPTION
## Description of the change

Fix `dateExpires` to be clear it works for all types

## Types of changes

- [x] Documentation content
- [ ] Page Layout / templates / structure
- [ ] Internal / code cleanup / build system
