### PR TITLE
LV: Removed isotope, fixes rendering and speeds up product news

### DIFF
--- a/src/containers/single/product-news.tsx
+++ b/src/containers/single/product-news.tsx
@@ -1,19 +1,43 @@
 //@ts-nocheck
-import React, { useLayoutEffect } from "react";
-import Isotope from "isotope-layout";
+import React, { useState, useCallback } from "react";
 import { useRouteData } from "react-static";
 
 //@ts-ignore
 import Markdown from "../../components/Markdown";
 import PageHeader from "../../components/PageHeader";
 
-export default function render() {
+const filterFns = {
+  // show if post if from the past 30 days
+  last_30: function (item) {
+    console.log("Date Published", item)
+    const postDate = new Date(item.datePublished).getTime() / 1000;
+    //var postDate = new Date($(this).find('.datePublished').text()).getTime() / 1000;
+    const thirtyDaysAgo = Math.floor(Date.now() / 1000) - 2592000;
+    return parseInt(postDate, 10) > thirtyDaysAgo;
+  },
+  past_year: function (item) {
+    const postDate = new Date(item.datePublished).getTime() / 1000;
+    const yearAgo = Math.floor(Date.now() / 1000) - 31536000;
+    return parseInt(postDate, 10) > yearAgo;
+  },
+};
 
+export default function render() {
   const { productNews } = useRouteData();
 
-  useLayoutEffect(() => {
-    if (document !== undefined) onLoad();
-  }, []);
+  const [date, setDate] = useState<string>("");
+  const [tag, setTags] = useState<string>("");
+
+  const dateChange = useCallback((e) => setDate(e.target.value), [setDate]);
+  const tagChange = useCallback((e) => setTags(e.target.value), [setTags]);
+
+  const filter = (item) => {
+    const matchesTags = tag === "" || (item.tags && item.tags.includes(tag));
+    const matchesDate = date === "" || filterFns[date](item);
+    return matchesTags && matchesDate;
+  };
+  const sort = (a, b) => new Date(b.datePublished).getTime() - new Date(a.datePublished).getTime();
+
   return (
     <>
       <PageHeader
@@ -22,14 +46,22 @@ export default function render() {
       >
         <div id="form-ui">
           <p>
-            <select className="isotope-product-news-select-group filters-isotope-product-news-select-group">
+            <select
+              value={tag}
+              onChange={tagChange}
+              className="isotope-product-news-select-group filters-isotope-product-news-select-group"
+            >
               <option value="">All Posts</option>
-              <option value=".feature-release">Feature Releases</option>
-              <option value=".monthly-update">Monthly Updates</option>
-              <option value=".product-update">Product Updates</option>
+              <option value="feature-release">Feature Releases</option>
+              <option value="monthly-update">Monthly Updates</option>
+              <option value="product-update">Product Updates</option>
             </select>
 
-            <select className="isotope-product-news-select-group filters-isotope-product-news-select-group">
+            <select
+              value={date}
+              onChange={dateChange}
+              className="isotope-product-news-select-group filters-isotope-product-news-select-group"
+            >
               <option value="">From All-time</option>
               <option value="last_30">Last 30 days</option>
               <option value="past_year">Past year</option>
@@ -38,111 +70,47 @@ export default function render() {
         </div>
 
         <div className="grid no-anchor">
-          {productNews.map((productNewsItem: any) => {
-            return (
-              <div
-                className={
-                  "product-news-item read-more-wrap " +
-                  (productNewsItem.tags && productNewsItem.tags.join(" "))
-                }
-              >
-                <div className="product-news-item-content">
-                  <i
-                    className="fa fa-2x fa-calendar product-news-item-icon"
-                    aria-hidden="true"
-                  ></i>
-                  <h3 className="no-anchor product-news-item-title">
-                    {productNewsItem.title}
-                  </h3>
-                  <p className="product-news-item-datePublished">
-                    {productNewsItem.datePublished}
-                  </p>
-                  <div className="product-news-item-post-content">
-                    <Markdown source={productNewsItem.content} />
+          {productNews
+            .filter(filter)
+            .sort(sort)
+            .map((productNewsItem: any) => {
+              return (
+                <div
+                  className={
+                    "product-news-item read-more-wrap " +
+                    (productNewsItem.tags && productNewsItem.tags.join(" "))
+                  }
+                >
+                  <div className="product-news-item-content">
+                    <i
+                      className="fa fa-2x fa-calendar product-news-item-icon"
+                      aria-hidden="true"
+                    ></i>
+                    <h3 className="no-anchor product-news-item-title">
+                      {productNewsItem.title}
+                    </h3>
+                    <p className="product-news-item-datePublished">
+                      {productNewsItem.datePublished}
+                    </p>
+                    <div className="product-news-item-post-content">
+                      <Markdown source={productNewsItem.content} />
+                    </div>
+                  </div>
+                  <div className="product-news-post-footer">
+                    <div className="product-news-post-footer-content">
+                      <p className="product-news-post-footer-title">Tags</p>{" "}
+                      {productNewsItem.tags.map((tag: string) => {
+                        return (
+                          <p className="product-news-item-footer-tag">{tag}</p>
+                        );
+                      })}
+                    </div>
                   </div>
                 </div>
-                <div className="product-news-post-footer">
-                  <div className="product-news-post-footer-content">
-                    <p className="product-news-post-footer-title">Tags</p>{" "}
-                    {productNewsItem.tags.map((tag: string) => {
-                      return (
-                        <p className="product-news-item-footer-tag">{tag}</p>
-                      );
-                    })}
-                  </div>
-                </div>
-              </div>
-            );
-          })}
+              );
+            })}
         </div>
       </PageHeader>
     </>
   );
-}
-
-function onLoad() {
-  // @ts-ignore -- should import
-  const $ = window.jQuery;
-
-  var lineHeight = 20;
-  var numLines = 1;
-  // init Isotope
-  // @ts-ignore
-  var iso = new Isotope(".grid", {
-    itemSelector: ".product-news-item",
-    layoutMode: "fitRows",
-    getSortData: {
-      date: function(itemElem) {
-        var unixDate =
-          new Date(
-            // @ts-ignore
-            $(itemElem)
-              .find(".product-news-item-datePublished")
-              .text()
-          ).getTime() / 1000;
-        // @ts-ignore
-        return parseInt(unixDate, 10);
-      }
-    },
-    sortBy: "date",
-    sortAscending: false
-  });
-  // filter functions
-  var filterFns = {
-    // show if post if from the past 30 days
-    last_30: function(itemElem) {
-      var postDate =
-        new Date(
-          $(itemElem)
-            .find(".product-news-item-datePublished")
-            .text()
-        ).getTime() / 1000;
-      //var postDate = new Date($(this).find('.datePublished').text()).getTime() / 1000;
-      var thirtyDaysAgo = Math.floor(Date.now() / 1000) - 2592000;
-      // @ts-ignore
-      return parseInt(postDate, 10) > thirtyDaysAgo;
-    },
-    past_year: function(itemElem) {
-      var postDate =
-        new Date(
-          $(itemElem)
-            .find(".product-news-item-datePublished")
-            .text()
-        ).getTime() / 1000;
-      var yearAgo = Math.floor(Date.now() / 1000) - 31536000;
-      // @ts-ignore
-      return parseInt(postDate, 10) > yearAgo;
-    }
-  };
-  // bind filter on select change
-  $(".filters-isotope-product-news-select-group").on("change", function() {
-    // get filter value from option value
-    var filterValue = this.value;
-
-    // use filterFn if matches value
-    filterValue = filterFns[filterValue] || filterValue;
-
-    //$grid.isotope({ filter: filterValue });
-    iso.arrange({ filter: filterValue });
-  });
 }

--- a/src/containers/single/product-news.tsx
+++ b/src/containers/single/product-news.tsx
@@ -56,7 +56,9 @@ export default function render() {
               <option value="monthly-update">Monthly Updates</option>
               <option value="product-update">Product Updates</option>
             </select>
-
+            {
+            " " // Spacing between form elements
+            }
             <select
               value={date}
               onChange={dateChange}


### PR DESCRIPTION
## Description of the change

Removed the isotope library on the product news page. Fixes a rendering issue, speeds on load times and filter times.

## Types of changes

- [ ] Documentation content
- [x] Page Layout / templates / structure
- [x] Internal / code cleanup / build system
