### PR TITLE
Improve spacing for multiline program libraries

### DIFF
--- a/src/containers/single/programLibrary.tsx
+++ b/src/containers/single/programLibrary.tsx
@@ -60,6 +60,7 @@ const LibraryH3 = styled.h3`
   justify-content: center;
   padding-left: 13px;
   height: 32px;
+  line-height: 1.6;
 `;
 
 const IconBorder = styled.div`
@@ -76,6 +77,7 @@ const IconBorder = styled.div`
   border-color: rgb(233, 233, 234);
   border-image: initial;
   text-align: center;
+  flex-shrink: 0;
 `;
 
 const ProgramIcon = styled.span`


### PR DESCRIPTION
## Description of the change

Shortens the space between lines in the header of a multiline program library (such as Referral Program With Objectives). Also disables shrinking of the library icon for longer headers.

## Types of changes

- [ ] Documentation content
- [X ] Page Layout / templates / structure
- [ ] Internal / code cleanup / build system
