### PR TITLE
Temporarily hide HTML to prevent flash of unstyled content (FOUC)

### DIFF
--- a/src/assets/js/docs.ts
+++ b/src/assets/js/docs.ts
@@ -40,72 +40,80 @@ export function init() {
     // search();
 
     // Scrolling not required in React-Static.
-    scrolling.init();
+    try {
+      scrolling.init();
 
-    jQuery(".navbar .hamburger").click(function (e) {
-      jQuery(this).toggleClass("is-active");
-    });
+      jQuery(".navbar .hamburger").click(function (e) {
+        jQuery(this).toggleClass("is-active");
+      });
+    } catch (e) {
+      // Scrolling failure
+      console.error("Jquery plugins failure", e);
+    }
 
     contentInit();
+
+    // Removes the `[hidden]` attribute from `html` set in `bottom.js` to prevent Flash of Unstyled Content (FOUC)
+    document.documentElement.removeAttribute("hidden");
   });
 }
 
 export function contentInit() {
-  try{
-  // LV: Waits for jQuery before loading
-  var magnific = require("magnific-popup");
+  try {
+    // LV: Waits for jQuery before loading
+    var magnific = require("magnific-popup");
 
-  const collapseExists = jQuery(".js-docs-collapse").length != 0;
-  const toggledRendered = jQuery(".js-docs-collapse-toggle");
+    const collapseExists = jQuery(".js-docs-collapse").length != 0;
+    const toggledRendered = jQuery(".js-docs-collapse-toggle");
 
-  //If there is already a collapse toggle element, then delete it
-  if(toggledRendered){
-    jQuery(".js-docs-collapse-toggle").remove()
-  }
+    //If there is already a collapse toggle element, then delete it
+    if (toggledRendered) {
+      jQuery(".js-docs-collapse-toggle").remove();
+    }
 
-  //If there are collapse elements, then create the collapse toggles for each one
-  if(collapseExists){
-    jQuery(".js-docs-collapse").each(function () {
-     var content = jQuery(this);
-     var toggler = jQuery("<a class='js-docs-collapse-toggle'>&nbsp;</a>").click(
-       function () {
-         jQuery(this).toggleClass("active");
-         content.toggle();
-       }
-     );
-     content.before(toggler);
-    });
-  }
+    //If there are collapse elements, then create the collapse toggles for each one
+    if (collapseExists) {
+      jQuery(".js-docs-collapse").each(function () {
+        var content = jQuery(this);
+        var toggler = jQuery(
+          "<a class='js-docs-collapse-toggle'>&nbsp;</a>"
+        ).click(function () {
+          jQuery(this).toggleClass("active");
+          content.toggle();
+        });
+        content.before(toggler);
+      });
+    }
 
-  // @ts-ignore
-  jQuery("[data-lightbox]").magnificPopup({
-    type: "image",
-    mainClass: "mfp-with-zoom", // this class is for CSS animation below
+    // @ts-ignore
+    jQuery("[data-lightbox]").magnificPopup({
+      type: "image",
+      mainClass: "mfp-with-zoom", // this class is for CSS animation below
 
-    zoom: {
-      enabled: true, // By default it's false, so don't forget to enable it
+      zoom: {
+        enabled: true, // By default it's false, so don't forget to enable it
 
-      duration: 300, // duration of the effect, in milliseconds
-      easing: "ease-in-out", // CSS transition easing function
+        duration: 300, // duration of the effect, in milliseconds
+        easing: "ease-in-out", // CSS transition easing function
 
-      // The "opener" function should return the element from which popup will be zoomed in
-      // and to which popup will be scaled down
-      // By defailt it looks for an image tag:
-      opener: function (openerElement) {
-        // openerElement is the element on which popup was initialized, in this case its <a> tag
-        // you don't need to add "opener" option if this code matches your needs, it's defailt one.
-        return openerElement.is("img")
-          ? openerElement
-          : openerElement.find("img");
+        // The "opener" function should return the element from which popup will be zoomed in
+        // and to which popup will be scaled down
+        // By defailt it looks for an image tag:
+        opener: function (openerElement) {
+          // openerElement is the element on which popup was initialized, in this case its <a> tag
+          // you don't need to add "opener" option if this code matches your needs, it's defailt one.
+          return openerElement.is("img")
+            ? openerElement
+            : openerElement.find("img");
+        },
       },
-    },
-  });
+    });
 
-  // Non-necessary highlighting. Executes asynchronously for faster page load
-  setTimeout(function () {
-    hljs.initHighlighting();
-  }, 1);
-  }catch(e){
+    // Non-necessary highlighting. Executes asynchronously for faster page load
+    setTimeout(function () {
+      hljs.initHighlighting();
+    }, 1);
+  } catch (e) {
     console.error("Jquery plugins failure", e);
   }
 }

--- a/src/templates/bottom.js
+++ b/src/templates/bottom.js
@@ -22,7 +22,7 @@ export function Bottom({
   const dotEnv = JSON.stringify(windowDotEnv);
   
   return (
-    <Html lang="en-US">
+    <Html lang="en-US" hidden={true}>
       <Head>
         <meta charSet="utf-8" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge,chrome=1" />
@@ -43,6 +43,7 @@ export function Bottom({
           rel="stylesheet"
           href="https://i.icomoon.io/public/830a3260df/SaaSquatch/style.css"
         />
+        <style dangerouslySetInnerHTML={{__html:`[hidden]{visibility:hidden;}`}} />
       </Head>
 
       <Body


### PR DESCRIPTION
## Description of the change

When you load the docs site for the first time not all the CSS has loaded, which results in a flash of unstyled content (FOUC). This PR takes a page from stencil.js, and applies a `hidden` attribute that is removed once all the JS has loaded.

## Types of changes

- [ ] Documentation content
- [x] Page Layout / templates / structure
- [ ] Internal / code cleanup / build system
