### PR TITLE
Prevent render of empty Timeline heading

### DIFF
--- a/src/containers/single/breaking-changes.tsx
+++ b/src/containers/single/breaking-changes.tsx
@@ -268,18 +268,18 @@ const Change = ({ mermaidMd, title, description, deadline }: ChangeProps) => {
             <Markdown source={description} />
           </Text>
         </div>
-        <div style={{ display: "flex", flexDirection: "column" }}>
-          <Name>Timeline</Name>
-          <Text>
-            <MermaidStyles>
-              {mermaidMd && (
+        {mermaidMd && (
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <Name>Timeline</Name>
+            <Text>
+              <MermaidStyles>
                 <div className="mermaid-markdown">
                   <Markdown source={mermaidMd} />
                 </div>
-              )}
-            </MermaidStyles>
-          </Text>
-        </div>
+              </MermaidStyles>
+            </Text>
+          </div>
+        )}
       </Body>
     </ChangeWrapper>
   );


### PR DESCRIPTION
Don't show the Timeline heading on breaking changes if there's no timeline

## Description of the change

> Description here

## Types of changes

- [ ] Documentation content
- [ ] Page Layout / templates / structure
- [ ] Internal / code cleanup / build system
