### PR TITLE
Fix HTTP links in docs header

### DIFF
--- a/src/navigation/NavigationHeader.tsx
+++ b/src/navigation/NavigationHeader.tsx
@@ -41,18 +41,13 @@ export function NavigationHeader() {
                   </a>
                 </li>
                 <li>
-                  <a href="http://www.saasquatch.com/resources/">
-                    Resources
-                  </a>
-                </li>
-                <li>
-                  <a href="http://www.saasquatch.com/blog/">Blog</a>
+                  <a href="https://www.saasquatch.com/blog/">Blog</a>
                 </li>
                 <li>
                   <a href="https://app.saasquatch.com/">Login</a>
                 </li>
                 <li>
-                  <a href="http://www.saasquatch.com/request-demo">
+                  <a href="https://www.saasquatch.com/request-demo">
                     Schedule a Demo
                   </a>
                 </li>


### PR DESCRIPTION
## Description of the change

We had some HTTP links in the header of the docs site, this was affecting site health. This PR updates those items to be HTTPS links. Also the resources page has been removed on the corporate site, so that link has been removed from the header by request from Zoe.

## Types of changes

- [ ] Documentation content
- [ ] Page Layout / templates / structure
- [x] Internal / code cleanup / build system
