### PR TITLE
Remove Items from sidebar

### DIFF
--- a/src/navigation/NavigationSidebar.tsx
+++ b/src/navigation/NavigationSidebar.tsx
@@ -272,8 +272,6 @@ export function NavigationSidebar() {
                     title="Setting Up a Reward Exchange Option"
                   />
                 </DropDown>
-
-                <ArticleLeaf to="/topics/conversion" title="Conversion" />
               </DropDown>
 
               <DropDown title="Program Emails">
@@ -400,11 +398,6 @@ export function NavigationSidebar() {
                 <ArticleLeaf
                   to="/features/participant-deletion"
                   title="Participant Deletion"
-                />
-                <ArticleLeaf to="/topics/attribution" title="Attribution" />
-                <ArticleLeaf
-                  to="/topics/identification"
-                  title="Identification"
                 />
               </DropDown>
 
@@ -608,14 +601,6 @@ export function NavigationSidebar() {
                 <ArticleLeaf
                   to="/features/message-links"
                   title="Message Links"
-                />
-                <ArticleLeaf
-                  to="/developer/conversion"
-                  title="Conversion Tech Guide"
-                />
-                <ArticleLeaf
-                  to="/developer/attribution"
-                  title="Attribution Tech Guide"
                 />
                 <ArticleLeaf
                   to="/bestpractices/common-pitfalls"


### PR DESCRIPTION
## Description of the change

> The following articles are removed from the sidebar:
> [Attribution](https://docs.saasquatch.com/topics/attribution)
> [Conversion](https://docs.saasquatch.com/topics/conversion/)
> [Conversion Tech Guide](https://docs.saasquatch.com/developer/conversion/)
> [Attribution Tech Guide](https://docs.saasquatch.com/developer/attribution/)
> [Identification](https://docs.saasquatch.com/topics/identification/)

## Types of changes

- [ ] Documentation content
- [ ] Page Layout / templates / structure
- [ ] Internal / code cleanup / build system
