### PR TITLE
Extra domains updates

### DIFF
--- a/src/navigation/NavigationSidebar.tsx
+++ b/src/navigation/NavigationSidebar.tsx
@@ -231,7 +231,7 @@ export function NavigationSidebar() {
                 />
                 <ArticleLeaf
                   to="/building-programs/participant-experiences/configuring-a-custom-domain"
-                  title="Configuring a Custom Domain"
+                  title="Setting Up a Domain"
                 />
               </DropDown>
 
@@ -336,10 +336,6 @@ export function NavigationSidebar() {
                 <ArticleLeaf
                   to="/building-programs/microsites/customizing-microsite-lifecycle-emails"
                   title="Customizing Microsite Lifecycle Emails"
-                />
-                <ArticleLeaf
-                  to="/setting-up-a-custom-subdomain-for-your-hosted-portal"
-                  title="Setting Up a Custom Domain for a Microsite"
                 />
                 <ArticleLeaf
                   to="/building-programs/microsites/microsite-editor"
@@ -586,10 +582,6 @@ export function NavigationSidebar() {
               <DropDown title="Dev Guides">
                 <ArticleLeaf to="/guides/" title="Overview" />
                 <ArticleLeaf to="/topics/email" title="SaaSquatch & Emails" />
-                <ArticleLeaf
-                  to="/customshortdomainguide"
-                  title="Custom Short Domains"
-                />
                 <ArticleLeaf
                   to="/developer/referral-security/"
                   title="Referral Security"


### PR DESCRIPTION
## Description of the change

> - change the sidebar doc name FROM Configuring a Custom Domain TO Setting Up a Domain
> - Remove Setting Up a Custom Domain for a Microsite
> - Remove Connect a custom domain for Share Links (this is listed in the sidebar as Custom Short Domains )

## Types of changes

- [ ] Documentation content
- [ ] Page Layout / templates / structure
- [ ] Internal / code cleanup / build system
