### PR TITLE
Redirect reference page to generated squatchjs docs

### DIFF
--- a/src/navigation/NavigationSidebar.tsx
+++ b/src/navigation/NavigationSidebar.tsx
@@ -61,13 +61,13 @@ export function NavigationSidebar() {
 
   const currentPage = stripTrailingSlash(history.location.pathname);
 
-  useEffect(() => {
+  useBrowserEffect(() => {
     if (
       window.location.pathname.startsWith("/developer/squatchjs/v2/reference")
     ) {
       window.location.replace("https://saasquatch.github.io/squatch-js");
     }
-  }, [window.location.pathname]);
+  }, [typeof window !== "undefined" && window.location.pathname]);
 
   return (
     <CurrentPageContext.Provider value={currentPage}>

--- a/src/navigation/NavigationSidebar.tsx
+++ b/src/navigation/NavigationSidebar.tsx
@@ -61,6 +61,14 @@ export function NavigationSidebar() {
 
   const currentPage = stripTrailingSlash(history.location.pathname);
 
+  useEffect(() => {
+    if (
+      window.location.pathname.startsWith("/developer/squatchjs/v2/reference")
+    ) {
+      window.location.replace("https://saasquatch.github.io/squatch-js");
+    }
+  }, [window.location.pathname]);
+
   return (
     <CurrentPageContext.Provider value={currentPage}>
       <Styles.Container>


### PR DESCRIPTION
## Description of the change

> Adds a redirect on page load for the `/developer/squatchjs/v2/reference` page, redirecting the browsers to https://saasquatch.github.io/squatch-js.

## Types of changes

- [x] Documentation content
- [ ] Page Layout / templates / structure
- [ ] Internal / code cleanup / build system
