### PR TITLE
Update sidebar

### DIFF
--- a/src/navigation/NavigationSidebar.tsx
+++ b/src/navigation/NavigationSidebar.tsx
@@ -218,12 +218,20 @@ export function NavigationSidebar() {
                   title="Participant Experiences"
                 />
                 <ArticleLeaf
-                  to="/building-programs/participant-experiences/saasquatch-components/"
-                  title="SaaSquatch Components"
+                  to="/building-programs/participant-experiences/configuring-a-custom-domain"
+                  title="Set Up a Domain"
                 />
                 <ArticleLeaf
-                  to="/building-programs/participant-experiences/configuring-a-custom-domain"
-                  title="Setting Up a Domain"
+                  to="/building-programs/participant-experiences/vanity-links-and-codes"
+                  title="Assign Vanity Share Links or Codes"
+                />
+                <ArticleLeaf
+                  to="/features/program-and-portal-statistics/"
+                  title="Widget and Microsite Statistics"
+                />
+                <ArticleLeaf
+                  to="/building-programs/participant-experiences/saasquatch-components/"
+                  title="SaaSquatch Components"
                 />
               </DropDown>
 
@@ -236,10 +244,6 @@ export function NavigationSidebar() {
                 <ArticleLeaf
                   to="/building-programs/program-widget/setting-up-an-instant-access-widget/"
                   title="Set Up an Instant Access Widget"
-                />
-                <ArticleLeaf
-                  to="/features/program-and-portal-statistics/"
-                  title="Program and Portal Statistics"
                 />
               </DropDown>
 


### PR DESCRIPTION
## Description of the change

* moves [Program and Portal Statistics](https://docs.saasquatch.com/features/program-and-portal-statistics) to Building Programs > Participant Experiences. 
* rename it to Widget and Microsite Statistics 
* add this new doc to Building Programs > Participant Experiences: [Assign Vanity Share Links or Referral Codes](https://docs.saasquatch.com/building-programs/participant-experiences/vanity-links-and-codes).
* reorder the Participant Experiences subcategory. should be:
   * Participant Experiences
   * Set Up a Domain
   * Assign Vanity Share Links or Codes
   * Widget and Microsite Statistics
   * SaaSquatch Components

## Types of changes

- [ ] Documentation content
- [ ] Page Layout / templates / structure
- [ ] Internal / code cleanup / build system
